### PR TITLE
Update Spools in UI on API call

### DIFF
--- a/octoprint_filamentmanager/api/__init__.py
+++ b/octoprint_filamentmanager/api/__init__.py
@@ -204,8 +204,8 @@ class FilamentManagerApi(octoprint.plugin.BlueprintPlugin):
         try:
             saved_spool = self.filamentManager.create_spool(new_spool)
 
-            if "update" in json_data:
-                update = json_data["update"]
+            if "updateui" in json_data:
+                update = json_data["updateui"]
                 if update == True:
                     self.send_client_message("data_changed", data=dict(table="spools", action="update"))
 
@@ -299,8 +299,8 @@ class FilamentManagerApi(octoprint.plugin.BlueprintPlugin):
         try:
             saved_selection = self.filamentManager.update_selection(identifier, self.client_id, selection)
 
-            if "update" in json_data:
-                update = json_data["update"]
+            if "updateui" in json_data:
+                update = json_data["updateui"]
                 if update == True:
                     self.send_client_message("data_changed", data=dict(table="spools", action="update"))
 

--- a/octoprint_filamentmanager/api/__init__.py
+++ b/octoprint_filamentmanager/api/__init__.py
@@ -25,6 +25,9 @@ from .util import *
 
 class FilamentManagerApi(octoprint.plugin.BlueprintPlugin):
 
+    def send_client_message(self, message_type, data=None):
+        self._plugin_manager.send_plugin_message(self._identifier, dict(type=message_type, data=data))
+
     @octoprint.plugin.BlueprintPlugin.route("/profiles", methods=["GET"])
     def get_profiles_list(self):
         force = request.values.get("force", "false") in valid_boolean_trues
@@ -200,6 +203,12 @@ class FilamentManagerApi(octoprint.plugin.BlueprintPlugin):
 
         try:
             saved_spool = self.filamentManager.create_spool(new_spool)
+
+            if "update" in json_data:
+                update = json_data["update"]
+                if update == True:
+                    self.send_client_message("data_changed", data=dict(table="spools", action="update"))
+
             return jsonify(dict(spool=saved_spool))
         except Exception as e:
             self._logger.error("Failed to create spool: {message}".format(message=str(e)))
@@ -289,6 +298,12 @@ class FilamentManagerApi(octoprint.plugin.BlueprintPlugin):
 
         try:
             saved_selection = self.filamentManager.update_selection(identifier, self.client_id, selection)
+
+            if "update" in json_data:
+                update = json_data["update"]
+                if update == True:
+                    self.send_client_message("data_changed", data=dict(table="spools", action="update"))
+
         except Exception as e:
             self._logger.error("Failed to update selected spool for tool{id}: {message}"
                                .format(id=str(identifier), message=str(e)))


### PR DESCRIPTION
Allows a client to update the ui when inserting or selecting spools. Previously a reload of the page was required.

Example api call:
```
url = 'http://localhost/plugin/filamentmanager/selections/0'
    headers = {'X-Api-Key': config.API_KEY}
    payload = {
        "selection": {
            "tool": 0, 
            "spool": {
                "id": id
            }   
        },
        "update": True
    }
```

The `update:True` is required to prevent normal calls from unnecessarily updating.

I am using this in my [project here](https://github.com/oschwartz10612/Filament-Manager-Barcodes) to update spools when scanned with a barcode scanner.