### PR TITLE
Fix extruder calculation with G2/G3

### DIFF
--- a/octoprint_filamentmanager/newodometer.py
+++ b/octoprint_filamentmanager/newodometer.py
@@ -43,7 +43,7 @@ class NewFilamentOdometer(object):
         T = self._getCodeInt(line, "T")
 
         if G is not None:
-            if G == 0 or G == 1:  # Move
+            if G >= 0 and G <= 3:  # Move G0/G1/G2/G3
                 x = self._getCodeFloat(line, "X")
                 y = self._getCodeFloat(line, "Y")
                 z = self._getCodeFloat(line, "Z")

--- a/octoprint_filamentmanager/odometer.py
+++ b/octoprint_filamentmanager/odometer.py
@@ -36,7 +36,7 @@ class FilamentOdometer(object):
         if gcode is None:
             return
 
-        if gcode == "G1" or gcode == "G0":  # move
+        if gcode in ("G0", "G1", "G2", "G3"):  # move
             e = self._get_float(cmd, self.regexE)
             if e is not None:
                 if self.relativeMode or self.relativeExtrusion:


### PR DESCRIPTION
When using this plugin with [Arc Welder](https://github.com/FormerLurker/ArcWelderPlugin) the extruded filament on arc moves was not calculated causing the final value to be lower than what the firmware reported.

The fix has been tested and it works.