### PR TITLE
Fixes for Python 3.11

### DIFF
--- a/octoprint_filamentmanager/data/__init__.py
+++ b/octoprint_filamentmanager/data/__init__.py
@@ -232,7 +232,8 @@ class FilamentManager(object):
             j = self.spools.join(self.profiles, self.spools.c.profile_id == self.profiles.c.id)
             stmt = select([self.spools, self.profiles]).select_from(j).order_by(self.spools.c.name)
             result = self.conn.execute(stmt)
-        return [self._build_spool_dict(row, row.keys()) for row in result.fetchall()]
+        column_names = [col.name for col in self.spools.columns] + [col.name for col in self.profiles.columns]
+        return [self._build_spool_dict(row, column_names) for row in result.fetchall()]
 
     def get_spools_lastmodified(self):
         with self.lock, self.conn.begin():
@@ -247,7 +248,10 @@ class FilamentManager(object):
                 .where(self.spools.c.id == identifier).order_by(self.spools.c.name)
             result = self.conn.execute(stmt)
         row = result.fetchone()
-        return self._build_spool_dict(row, row.keys()) if row is not None else None
+        if row is None:
+            return None
+        column_names = [col.name for col in self.spools.columns] + [col.name for col in self.profiles.columns]
+        return self._build_spool_dict(row, column_names)
 
     def create_spool(self, data):
         with self.lock, self.conn.begin():
@@ -293,7 +297,8 @@ class FilamentManager(object):
             stmt = select([self.selections, self.spools, self.profiles]).select_from(j2)\
                 .where(self.selections.c.client_id == client_id).order_by(self.selections.c.tool)
         result = self.conn.execute(stmt)
-        return [self._build_selection_dict(row, row.keys()) for row in result.fetchall()]
+        column_names = [col.name for col in self.selections.columns] + [col.name for col in self.spools.columns] + [col.name for col in self.profiles.columns]
+        return [self._build_selection_dict(row, column_names) for row in result.fetchall()]
 
     def get_selection(self, identifier, client_id):
         with self.lock, self.conn.begin():
@@ -303,7 +308,10 @@ class FilamentManager(object):
                 .where((self.selections.c.tool == identifier) & (self.selections.c.client_id == client_id))
         result = self.conn.execute(stmt)
         row = result.fetchone()
-        return self._build_selection_dict(row, row.keys()) if row is not None else dict(tool=identifier, spool=None)
+        if row is None:
+            return dict(tool=identifier, spool=None)
+        column_names = [col.name for col in self.selections.columns] + [col.name for col in self.spools.columns] + [col.name for col in self.profiles.columns]
+        return self._build_selection_dict(row, column_names)
 
     def update_selection(self, identifier, client_id, data):
         with self.lock, self.conn.begin():

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_url = "https://github.com/OllisGit/OctoPrint-FilamentManager"
 plugin_license = "AGPLv3"
 plugin_requires = ["backports.csv>=1.0.5,<1.1",
                    "uritools>=2.1,<2.2",
-                   "SQLAlchemy>=1.1.15,<1.2"]
+                   "SQLAlchemy>=1.4,<1.5"]
 plugin_additional_data = []
 plugin_additional_packages = []
 plugin_ignored_packages = []


### PR DESCRIPTION
Include patch from @leigh-johnson (bump version of SQLAlchemy).
Fix crashes and not updating spool usage after print on system with Python 3.11.
Should be safe also for older versions of Python.

Fixes: #131, #130, #126, #124, #119, #116, #93.